### PR TITLE
Make chrome logo text-primary to avoid turn to black on hover

### DIFF
--- a/curriculum/templates/curriculum/lessonplan_find_share.html
+++ b/curriculum/templates/curriculum/lessonplan_find_share.html
@@ -120,7 +120,7 @@
                                 {% endif %}
                                 {% if lessonplan.web_only %}
                                     <p class="pr-4" title="Chromebook compatible"><i
-                                            class="text-right fab fa-chrome"></i></p>
+                                            class="text-primary text-right fab fa-chrome"></i></p>
                                 {% endif %}
                             </div>
                             <p class="curriculum-text">{{ lessonplan.summary|truncatechars:200 }}</p>


### PR DESCRIPTION
This fix ensures that the chrome logo icon stays green whether or not the user is hovering their mouse over the card. @jaedynlee is this the issue you mentioned in #57 