### PR TITLE
Remove extra height under landing page sections

### DIFF
--- a/firstbyte/static/firstbyte/style/main.css
+++ b/firstbyte/static/firstbyte/style/main.css
@@ -170,7 +170,6 @@ footer a:hover {
     font-weight: normal;
     text-decoration: none;
     font-size: 0.75em;
-    height: 15rem;
     overflow-x: hidden;
     overflow-y: auto;
 }


### PR DESCRIPTION
Removes excess space from landing page -- see current website for comparison.

![image](https://user-images.githubusercontent.com/3858161/77120272-cc6cf300-6a0e-11ea-9d2b-377b878fadeb.png)
