### PR TITLE
add get involved anchor

### DIFF
--- a/templates/firstbyte/base.html
+++ b/templates/firstbyte/base.html
@@ -30,6 +30,7 @@
             <div class="navbar-nav">
                 <a class="nav-item nav-link mx-2" href="{% url 'index' %}">About</a>
                 <a class="nav-item nav-link mx-2" href="{% url 'team' %}">Meet the Team</a>
+                <a class="nav-item nav-link mx-2" href="{% url 'team' %}#get-involved">Get Involved</a>
                 <a class="nav-item nav-link mx-2" href="{% url 'list-lesson-plan' %}">Find & Share Curricula</a>
                 <a class="nav-item nav-link mx-2" href="{% url 'loaner-program' %}">Loaner Program</a>
             </div>


### PR DESCRIPTION
Adds back "Get Involved" to the navbar, but links it to the Get Involved *section* of the Meet the Team page

![Screenshot from 2020-04-04 21-18-37](https://user-images.githubusercontent.com/3858161/78464650-dd2d9200-76b9-11ea-8f53-20c0feb19ec4.png)
